### PR TITLE
add appveyor to support multi platform of docker build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+image:
+  - Ubuntu
+  - Visual Studio 2019
+
+environment:
+  matrix:
+    - ARCH: amd64
+
+build_script:
+  - pwsh: ./build.ps1
+
+test_script:
+  - pwsh: ./test.ps1
+
+deploy_script:
+  - ps: ./deploy.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host Starting build
+
+docker info
+$os = If ($isWindows) {'windows'} Else {'linux'}
+docker build --tag containertest --file "${os}.dockerfile" .

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,86 @@
+# Credit to https://github.com/StefanScherer
+
+$ErrorActionPreference = 'Stop'
+
+if (! (Test-Path Env:\APPVEYOR_REPO_TAG_NAME)) {
+  Write-Host "No version tag detected. Skip publishing."
+  exit 0
+}
+
+Write-Host Starting deploy
+
+$image = '3shape/containerized-structure-test'
+$auth =[System.Text.Encoding]::UTF8.GetBytes("$($env:DOCKER_USER):$($env:DOCKER_PASS)")
+$auth64 = [Convert]::ToBase64String($auth)
+
+if (!(Test-Path ~/.docker)) { mkdir ~/.docker }
+
+@"
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "$auth64"
+    }
+  },
+  "experimental": "enabled"
+}
+"@ | Out-File -Encoding Ascii ~/.docker/config.json
+
+$os = If ($isWindows) {'windows'} Else {'linux'}
+
+docker tag containertest "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME"
+docker push "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME"
+
+if ($isWindows) {
+  Write-Host "Rebasing image to produce 2016/1607 variant"
+  npm install -g rebase-docker-image
+  rebase-docker-image `
+    "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME" `
+    -s mcr.microsoft.com/windows/nanoserver:1809 `
+    -t "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME-1607" `
+    -b mcr.microsoft.com/windows/nanoserver:sac2016
+
+  Write-Host "Rebasing image to produce 1709 variant"
+  rebase-docker-image `
+    "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME" `
+    -s mcr.microsoft.com/windows/nanoserver:1809 `
+    -t "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME-1709" `
+    -b mcr.microsoft.com/windows/nanoserver:1709
+
+  Write-Host "Rebasing image to produce 1803 variant"
+  rebase-docker-image `
+    "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME" `
+    -s mcr.microsoft.com/windows/nanoserver:1809 `
+    -t "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME-1803" `
+    -b mcr.microsoft.com/windows/nanoserver:1803
+
+  Write-Host "Rebasing image to produce 1903 variant"
+  rebase-docker-image `
+    "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME" `
+    -s mcr.microsoft.com/windows/nanoserver:1809 `
+    -t "${image}:$os-$env:ARCH-$env:APPVEYOR_REPO_TAG_NAME-1903" `
+    -b mcr.microsoft.com/windows/nanoserver:1903
+} else {
+  # Linux
+  if ($env:ARCH -eq "amd64") {
+    # The last in the build matrix
+    docker -D manifest create "$($image):$env:APPVEYOR_REPO_TAG_NAME" `
+      "$($image):linux-amd64-$env:APPVEYOR_REPO_TAG_NAME" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1607" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1709" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1803" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1903"
+    docker manifest push "$($image):$env:APPVEYOR_REPO_TAG_NAME"
+
+    Write-Host "Pushing manifest $($image):latest"
+    docker -D manifest create "$($image):latest" `
+      "$($image):linux-amd64-$env:APPVEYOR_REPO_TAG_NAME" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1607" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1709" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1803" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME" `
+      "$($image):windows-amd64-$env:APPVEYOR_REPO_TAG_NAME-1903"
+    docker manifest push "$($image):latest"
+  }
+}

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'SilentlyContinue'
+
+if ($env:ARCH -ne "amd64") {
+  Write-Host "Arch $env:ARCH detected. Skip testing."
+  exit 0
+}
+
+Write-Host Starting test
+
+docker kill containertest-test
+docker rm -f containertest-test
+
+$ErrorActionPreference = 'Stop';
+
+if ($IsWindows) {
+  docker pull mcr.microsoft.com/windows/nanoserver:1809
+  docker run --name containertest-test --rm -v "${PWD}:C:/configs" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine containertest test -c /configs/gc-windows-config.yml -i mcr.microsoft.com/windows/nanoserver:1809
+} else {
+  docker pull ubuntu:18.04
+  docker run --name containertest-test --rm -v "${PWD}:/configs" -v /var/run/docker.sock:/var/run/docker.sock containertest test -c /configs/gc-linux-config.yml -i ubuntu:18.04
+}


### PR DESCRIPTION
Thanks to https://github.com/StefanScherer
Especially this: https://github.com/StefanScherer/whoami
and https://stefanscherer.github.io/use-appveyor-to-build-multi-arch-docker-image/

cc @zionyx